### PR TITLE
Patch cmb2-conditionals.js for group fields

### DIFF
--- a/cmb2-conditionals.js
+++ b/cmb2-conditionals.js
@@ -10,6 +10,11 @@ jQuery(document).ready(function($) {
 			var $e = $(e),
 				id = $e.data('conditional-id'),
 				value = $e.data('conditional-value');
+				
+			if ( id.match('{#}') ) {
+				id = id.replace('{#}', $e.closest('[data-iterator]').data('iterator') );
+				$e.attr('data-conditional-id', id);
+			}
 
 			var	$element = $('[name="' + id + '"]'),
 				$parent = $e.parents('.cmb-row:first').hide();


### PR DESCRIPTION
As I explained in issue #2, this simple fix on the JS coupled with a proper _data-conditional-id_ makes this plugin work properly for repeating groups.

The proper attribute for fields inside of repeating groups would be 

<pre>'data-conditional-id' => 'XXXXX[{#}][YYYYY]'</pre>

where **XXXXX** is the group's id and **YYYYY** the data-conditional-id.
